### PR TITLE
ci: update CODEOWNERS file for hiero repo move

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
+*                                               @hiero-ledger/hiero-swift-maintainers
 
 #########################
 #####  Core Files  ######
@@ -11,30 +11,30 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
-/.github/dependabot.yml                         @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers  @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
+/.github/                                       @hiero-ledger/github-maintainers @hiero-ledger/github-committers
+/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/github-committers
+/.github/dependabot.yml                         @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
 
 # Swift project files and inline plugins
-**/.swift-format.json                           @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
-**/.swiftlint.yml                               @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
-**/Package.swift                                @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
-**/Package.resolved                             @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
+**/.swift-format.json                           @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
+**/.swiftlint.yml                               @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
+**/Package.swift                                @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
+**/Package.resolved                             @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
 
 # Codacy Tool Configurations
-/config/                                        @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
-.remarkrc                                       @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
+/config/                                        @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
+.remarkrc                                       @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
-/CODEOWNERS                                     @hashgraph/release-engineering-managers
+/CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
-**/LICENSE                                      @hashgraph/release-engineering-managers
+/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
+**/LICENSE                                      @hiero-ledger/github-maintainers
 
 # CodeCov configuration
-**/codecov.yml                                  @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
+**/codecov.yml                                  @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
-**/.gitignore.*                                 @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/hedera-sdk @hashgraph/hedera-sdk-swift-contributors @hashgraph/launchbadge-hedera
+**/.gitignore                                   @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers
+**/.gitignore.*                                 @hiero-ledger/github-committers @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-swift-maintainers @hiero-ledger/hiero-sdk-swift-committers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @hiero-ledger/hiero-swift-maintainers
+*                                               @hiero-ledger/hiero-sdk-swift-maintainers
 
 #########################
 #####  Core Files  ######


### PR DESCRIPTION
**Description**:

Update the CODEOWNERS file for the move to `hiero-ledger` organization.

**Related Issue(s)**:

Fixes #431