### PR TITLE
Streamline Key and Alias specifications for `AccountCreateTransaction`

### DIFF
--- a/Examples/AccountAllowance/main.swift
+++ b/Examples/AccountAllowance/main.swift
@@ -52,7 +52,7 @@ private func createAccount(_ client: Client, _ name: StaticString) async throws 
     let key = PrivateKey.generateEd25519()
 
     let reciept = try await AccountCreateTransaction()
-        .key(.single(key.publicKey))
+        .keyWithoutAlias(.single(key.publicKey))
         .initialBalance(5)
         .accountMemo("[sdk::swift::accountAllowanceExample::\(name)]")
         .execute(client)

--- a/Examples/AddNftAllowance/main.swift
+++ b/Examples/AddNftAllowance/main.swift
@@ -77,14 +77,14 @@ internal enum Program {
         let receiverKey = PrivateKey.generateEd25519()
 
         let spenderAccountId = try await AccountCreateTransaction()
-            .key(Key.single(spenderKey.publicKey))
+            .keyWithoutAlias(Key.single(spenderKey.publicKey))
             .initialBalance(Hbar(2))
             .execute(client)
             .getReceipt(client)
             .accountId!
 
         let receiverAccountId = try await AccountCreateTransaction()
-            .key(Key.single(receiverKey.publicKey))
+            .keyWithoutAlias(Key.single(receiverKey.publicKey))
             .initialBalance(Hbar(2))
             .execute(client)
             .getReceipt(client)

--- a/Examples/CreateAccount/main.swift
+++ b/Examples/CreateAccount/main.swift
@@ -35,7 +35,7 @@ internal enum Program {
         print("public key = \(newKey.publicKey)")
 
         let response = try await AccountCreateTransaction()
-            .key(.single(newKey.publicKey))
+            .keyWithoutAlias(.single(newKey.publicKey))
             .initialBalance(5)
             .execute(client)
 

--- a/Examples/CreateAccountThresholdKey/main.swift
+++ b/Examples/CreateAccountThresholdKey/main.swift
@@ -51,7 +51,7 @@ internal enum Program {
         )
 
         let transactionResponse = try await AccountCreateTransaction()
-            .key(.keyList(transactionKey))
+            .keyWithoutAlias(.keyList(transactionKey))
             .initialBalance(Hbar(10))
             .execute(client)
 

--- a/Examples/CreateAccountWithAlias/main.swift
+++ b/Examples/CreateAccountWithAlias/main.swift
@@ -1,0 +1,166 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2025 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import Foundation
+import Hiero
+import SwiftDotenv
+
+@main
+internal enum Program {
+    internal static func main() async throws {
+        print("Starting Example")
+        let env = try Dotenv.load()
+        let client = try Client.forName(env.networkName)
+
+        client.setOperator(env.operatorAccountId, env.operatorKey)
+        // Creates a Hedera account with an alias using an ECDSA key.
+        try await createAccountWithAlias(client)
+        // Creates a Hedera account with both ED25519 and ECDSA keys.
+        try await createAccountWithBothKeys(client)
+        // Creates a Hedera account without an alias.
+        try await createAccountWithoutAlias(client)
+
+        print("Example finished")
+    }
+
+    internal static func createAccountWithAlias(_ client: Client) async throws {
+        print("Creating account with alias")
+
+        // Step 1:
+        // Create a new ECDSA key
+        let privateKey = PrivateKey.generateEcdsa()
+
+        // Step 2:
+        // Extract the ECDSA public key and generate EVM address
+        let publicKey = privateKey.publicKey
+        let evmAddress = publicKey.toEvmAddress()!
+
+        // Step 3:
+        // Create the account with an alias
+        let accountId = try await AccountCreateTransaction()
+            .keyWithAlias(privateKey)
+            .freezeWith(client)
+            .sign(privateKey)
+            .execute(client)
+            .getReceipt(client)
+            .accountId!
+
+        // Step 4:
+        // Query account info
+        let info = try await AccountInfoQuery()
+            .accountId(accountId)
+            .execute(client)
+
+        print("Initial EVM address: \(evmAddress) is the same as \(info.contractAccountId)")
+    }
+
+    // Creates an account with an alias and a key
+    internal static func createAccountWithBothKeys(_ client: Client) async throws {
+        print("Creating account with an alias and a key")
+
+        // Step 1:
+        // Create a new ECDSA key and Ed25519 key
+        let ed25519Key = PrivateKey.generateEd25519()
+        let ecdsaKey = PrivateKey.generateEcdsa()
+
+        // Step 2:
+        // Extract the ECDSA public key and generate EVM address
+        let evmAddress = ecdsaKey.publicKey.toEvmAddress()!
+
+        // Step 3:
+        // Create the account with both keys. Transaction needs to be signed
+        // by both keys.
+        let accountId = try await AccountCreateTransaction()
+            .keyWithAlias(.single(ed25519Key.publicKey), ecdsaKey)
+            .freezeWith(client)
+            .sign(ed25519Key)
+            .sign(ecdsaKey)
+            .execute(client)
+            .getReceipt(client)
+            .accountId!
+
+        // Step 4:
+        // Query account info
+        let info = try await AccountInfoQuery()
+            .accountId(accountId)
+            .execute(client)
+
+        print("Account's key: \(info.key) is the same as \(ed25519Key.publicKey)")
+        print("Initial EVM address: \(evmAddress) is the same as \(info.contractAccountId)")
+    }
+
+    // Creates an account without an alias.
+    internal static func createAccountWithoutAlias(_ client: Client) async throws {
+        print("Creating account without an alias")
+
+        // Step 1:
+        // Create a new ECDSA key
+        let privateKey = PrivateKey.generateEcdsa()
+
+        // Step 2:
+        // Create an account without an alias.
+        let accountId = try await AccountCreateTransaction()
+            .keyWithoutAlias(.single(privateKey.publicKey))
+            .freezeWith(client)
+            .sign(privateKey)
+            .execute(client)
+            .getReceipt(client)
+            .accountId!
+
+        // Step 3:
+        // Query account info
+        let info = try await AccountInfoQuery()
+            .accountId(accountId)
+            .execute(client)
+
+        let isZeroAddress = isZeroAddress(try info.contractAccountId.bytes)
+
+        print("Account's key: \(info.key) is the same as \(privateKey.publicKey)")
+        print("Account has no alias: \(isZeroAddress)")
+    }
+
+    // Checks if an address is a zero address (all first 12 bytes are zero)
+    internal static func isZeroAddress(_ address: [UInt8]) -> Bool {
+        // Check first 12 bytes are all zero
+        for byte in address[..<12] where byte != 0 {
+            return false
+        }
+        return true
+    }
+}
+
+extension Environment {
+    /// Account ID for the operator to use in this example.
+    internal var operatorAccountId: AccountId {
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
+    }
+
+    /// Private key for the operator to use in this example.
+    internal var operatorKey: PrivateKey {
+        PrivateKey(self["OPERATOR_KEY"]!.stringValue)!
+    }
+
+    /// The name of the hedera network this example should be ran against.
+    ///
+    /// Testnet by default.
+    internal var networkName: String {
+        self["HEDERA_NETWORK"]?.stringValue ?? "testnet"
+    }
+}

--- a/Examples/InitializeClientWithMirrorNetwork/main.swift
+++ b/Examples/InitializeClientWithMirrorNetwork/main.swift
@@ -45,7 +45,7 @@ internal enum Program {
         * Step 2: Create an account
         */
         let aliceId = try await AccountCreateTransaction()
-            .key(.single(privateKey.publicKey))
+            .keyWithoutAlias(.single(privateKey.publicKey))
             .initialBalance(Hbar(5))
             .execute(client)
             .getReceipt(client)

--- a/Examples/LongTermScheduledTransaction/main.swift
+++ b/Examples/LongTermScheduledTransaction/main.swift
@@ -51,7 +51,7 @@ internal enum Program {
         */
         print("Creating new account... (w/ above key list as an account key).")
         let aliceId = try await AccountCreateTransaction()
-            .key(.keyList(thresholdKey))
+            .keyWithoutAlias(.keyList(thresholdKey))
             .initialBalance(Hbar(2))
             .execute(client)
             .getReceipt(client)

--- a/Examples/MultiAppTransfer/main.swift
+++ b/Examples/MultiAppTransfer/main.swift
@@ -39,7 +39,7 @@ internal enum Program {
         let exchangeAccountId = try await AccountCreateTransaction()
             // the exchange only accepts transfers that it validates through a side channel (e.g. REST API)
             .receiverSignatureRequired(true)
-            .key(.single(exchangeKey.publicKey))
+            .keyWithoutAlias(.single(exchangeKey.publicKey))
             // The owner key has to sign this transaction
             // when receiver_signature_required is true
             .freezeWith(client)
@@ -52,7 +52,7 @@ internal enum Program {
         // the user with a balance of 5 h
         let userAccountId = try await AccountCreateTransaction()
             .initialBalance(Hbar(5))
-            .key(.single(userKey.publicKey))
+            .keyWithoutAlias(.single(userKey.publicKey))
             .execute(client)
             .getReceipt(client)
             .accountId!

--- a/Examples/MultiSigOffline/main.swift
+++ b/Examples/MultiSigOffline/main.swift
@@ -42,7 +42,7 @@ internal enum Program {
 
         let createAccountTransaction = try await AccountCreateTransaction()
             .initialBalance(2)
-            .key(.keyList(keylist))
+            .keyWithoutAlias(.keyList(keylist))
             .execute(client)
 
         let accountId = try await createAccountTransaction.getReceipt(client).accountId!

--- a/Examples/NftUpdateMetadata/main.swift
+++ b/Examples/NftUpdateMetadata/main.swift
@@ -77,7 +77,7 @@ internal enum Program {
         let nftSerials = tokenMintReceipt.serials!
 
         let accountCreateTransaction = try await AccountCreateTransaction()
-            .key(.single(env.operatorKey.publicKey))
+            .keyWithoutAlias(.single(env.operatorKey.publicKey))
             .maxAutomaticTokenAssociations(10)
             .execute(client)
 

--- a/Examples/Schedule/main.swift
+++ b/Examples/Schedule/main.swift
@@ -42,7 +42,7 @@ internal enum Program {
         print("public key 2 = \(key2.publicKey)")
 
         let newAccountId = try await AccountCreateTransaction()
-            .key(.keyList([.single(key1.publicKey), .single(key2.publicKey)]))
+            .keyWithoutAlias(.keyList([.single(key1.publicKey), .single(key2.publicKey)]))
             .initialBalance(.fromTinybars(1000))
             .execute(client)
             .getReceipt(client)

--- a/Examples/ScheduleIdenticalTransaction/main.swift
+++ b/Examples/ScheduleIdenticalTransaction/main.swift
@@ -49,7 +49,7 @@ internal enum Program {
             print("public key: \(publicKey)")
 
             let receipt = try await AccountCreateTransaction()
-                .key(.single(publicKey))
+                .keyWithoutAlias(.single(publicKey))
                 .initialBalance(Hbar(1))
                 .execute(client)
                 .getReceipt(client)
@@ -74,7 +74,7 @@ internal enum Program {
         // The key that must sign each transfer out of the account. If receiverSigRequired is true, then
         // it must also sign any transfer into the account.
         let thresholdAccount = try await AccountCreateTransaction()
-            .key(.keyList(keyList))
+            .keyWithoutAlias(.keyList(keyList))
             .initialBalance(Hbar(10))
             .execute(client)
             .getReceipt(client)

--- a/Examples/ScheduleMultiSigTransaction/main.swift
+++ b/Examples/ScheduleMultiSigTransaction/main.swift
@@ -54,7 +54,7 @@ internal enum Program {
         // The only _required_ property here is `key`
         let response = try await AccountCreateTransaction()
             .nodeAccountIds([3])
-            .key(.keyList(keyList))
+            .keyWithoutAlias(.keyList(keyList))
             .initialBalance(Hbar(10))
             .execute(client)
 

--- a/Examples/ScheduledTransactionMultiSigThreshold/main.swift
+++ b/Examples/ScheduledTransactionMultiSigThreshold/main.swift
@@ -48,7 +48,7 @@ internal enum Program {
         )
 
         let receipt = try await AccountCreateTransaction()
-            .key(.keyList(transactionKey))
+            .keyWithoutAlias(.keyList(transactionKey))
             .initialBalance(.fromTinybars(1))
             .accountMemo("3-of-4 multi-sig account")
             .execute(client)

--- a/Examples/ScheduledTransfer/main.swift
+++ b/Examples/ScheduledTransfer/main.swift
@@ -59,7 +59,7 @@ internal enum Program {
 
         let bobsId = try await AccountCreateTransaction()
             .receiverSignatureRequired(true)
-            .key(.single(bobsKey.publicKey))
+            .keyWithoutAlias(.single(bobsKey.publicKey))
             .initialBalance(10)
             .freezeWith(client)
             .sign(bobsKey)

--- a/Examples/Staking/main.swift
+++ b/Examples/Staking/main.swift
@@ -44,7 +44,7 @@ internal enum Program {
         // If you really want to stake to node 0, you should use
         // `.setStakedNodeId()` instead
         let newAccountId = try await AccountCreateTransaction()
-            .key(.single(newKey.publicKey))
+            .keyWithoutAlias(.single(newKey.publicKey))
             .initialBalance(Hbar(10))
             .stakedAccountId("0.0.3")
             .execute(client)

--- a/Examples/StakingWithUpdate/main.swift
+++ b/Examples/StakingWithUpdate/main.swift
@@ -44,7 +44,7 @@ internal enum Program {
         // If you really want to stake to node 0, you should use
         // `.setStakedNodeId()` instead
         let newAccountId = try await AccountCreateTransaction()
-            .key(.single(newKey.publicKey))
+            .keyWithoutAlias(.single(newKey.publicKey))
             .initialBalance(Hbar(10))
             .stakedAccountId("0.0.3")
             .execute(client)

--- a/Examples/TokenAirdrop/main.swift
+++ b/Examples/TokenAirdrop/main.swift
@@ -32,7 +32,7 @@ internal enum Program {
 
         let privateKey1 = PrivateKey.generateEcdsa()
         let aliceId = try await AccountCreateTransaction()
-            .key(.single(privateKey1.publicKey))
+            .keyWithoutAlias(.single(privateKey1.publicKey))
             .initialBalance(Hbar(10))
             .maxAutomaticTokenAssociations(-1)
             .execute(client)
@@ -41,7 +41,7 @@ internal enum Program {
 
         let privateKey2 = PrivateKey.generateEcdsa()
         let bobId = try await AccountCreateTransaction()
-            .key(.single(privateKey2.publicKey))
+            .keyWithoutAlias(.single(privateKey2.publicKey))
             .maxAutomaticTokenAssociations(1)
             .execute(client)
             .getReceipt(client)
@@ -49,7 +49,7 @@ internal enum Program {
 
         let privateKey3 = PrivateKey.generateEcdsa()
         let carolId = try await AccountCreateTransaction()
-            .key(.single(privateKey3.publicKey))
+            .keyWithoutAlias(.single(privateKey3.publicKey))
             .maxAutomaticTokenAssociations(0)
             .execute(client)
             .getReceipt(client)
@@ -57,7 +57,7 @@ internal enum Program {
 
         let treasuryKey = PrivateKey.generateEcdsa()
         let treasuryAccountId = try await AccountCreateTransaction()
-            .key(.single(treasuryKey.publicKey))
+            .keyWithoutAlias(.single(treasuryKey.publicKey))
             .initialBalance(Hbar(10))
             .execute(client)
             .getReceipt(client)

--- a/Examples/TransferTokens/main.swift
+++ b/Examples/TransferTokens/main.swift
@@ -145,7 +145,7 @@ internal enum Program {
         print("public key = \(privateKey.publicKey)")
 
         let receipt = try await AccountCreateTransaction()
-            .key(.single(privateKey.publicKey))
+            .keyWithoutAlias(.single(privateKey.publicKey))
             .initialBalance(.fromTinybars(1000))
             .execute(client)
             .getReceipt(client)

--- a/Examples/UpdateAccountPublicKey/main.swift
+++ b/Examples/UpdateAccountPublicKey/main.swift
@@ -16,7 +16,7 @@ internal enum Program {
         let key2 = PrivateKey.generateEd25519()
 
         let createResponse = try await AccountCreateTransaction()
-            .key(.single(key1.publicKey))
+            .keyWithoutAlias(.single(key1.publicKey))
             .initialBalance(1)
             .execute(client)
 

--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,7 @@ let exampleTargets = [
     "TokenAirdrop",
     "InitializeClientWithMirrorNetwork",
     "LongTermScheduledTransaction",
+    "CreateAccountWithAlias",
 ].map { name in
     Target.executableTarget(
         name: "\(name)Example",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,8 +36,6 @@ tasks:
 
     submodule:move:
         desc: "Copy all contents from protobufs/hapi/hedera-protobufs to Sources/HieroProtobufs/Protos"
-        deps: 
-            - submodule:install
         cmds:
             - mkdir -p Sources/HieroProtobufs/Protos/mirror
             - mkdir -p Sources/HieroProtobufs/Protos/sdk

--- a/Tests/HieroE2ETests/Account/Account.swift
+++ b/Tests/HieroE2ETests/Account/Account.swift
@@ -47,7 +47,7 @@ internal struct Account {
         try await testEnv.ratelimits.accountCreate()
 
         let receipt = try await AccountCreateTransaction()
-            .key(accountKey)
+            .keyWithoutAlias(accountKey)
             .initialBalance(Hbar(1))
             .maxAutomaticTokenAssociations(maxAutomaticTokenAssociations)
             .execute(testEnv.client)

--- a/Tests/HieroE2ETests/Account/AccountDelete.swift
+++ b/Tests/HieroE2ETests/Account/AccountDelete.swift
@@ -29,7 +29,7 @@ internal final class AccountDelete: XCTestCase {
 
         try await testEnv.ratelimits.accountCreate()
         let receipt = try await AccountCreateTransaction()
-            .key(.single(key.publicKey))
+            .keyWithoutAlias(.single(key.publicKey))
             .initialBalance(1)
             .execute(testEnv.client)
             .getReceipt(testEnv.client)

--- a/Tests/HieroE2ETests/Account/AccountUpdate.swift
+++ b/Tests/HieroE2ETests/Account/AccountUpdate.swift
@@ -29,7 +29,7 @@ internal final class AccountUpdate: XCTestCase {
         let key2 = PrivateKey.generateEd25519()
 
         let receipt = try await AccountCreateTransaction()
-            .key(.single(key1.publicKey))
+            .keyWithoutAlias(.single(key1.publicKey))
             .execute(testEnv.client)
             .getReceipt(testEnv.client)
 
@@ -96,7 +96,7 @@ internal final class AccountUpdate: XCTestCase {
 
         // Create account with max token associations of 1
         let accountCreateReceipt = try await AccountCreateTransaction()
-            .key(.single(accountKey.publicKey))
+            .keyWithoutAlias(.single(accountKey.publicKey))
             .maxAutomaticTokenAssociations(1)
             .execute(testEnv.client)
             .getReceipt(testEnv.client)

--- a/Tests/HieroE2ETests/Schedule/ScheduleCreate.swift
+++ b/Tests/HieroE2ETests/Schedule/ScheduleCreate.swift
@@ -38,7 +38,7 @@ internal class ScheduleCreate: XCTestCase {
         let transaction = AccountCreateTransaction()
         let accountReceipt =
             try await transaction
-            .key(.keyList(keyList))
+            .keyWithoutAlias(.keyList(keyList))
             .initialBalance(Hbar(1))
             .execute(testEnv.client)
 
@@ -183,7 +183,7 @@ internal class ScheduleCreate: XCTestCase {
         let privateKey = PrivateKey.generateEd25519()
 
         let accountId = try await AccountCreateTransaction()
-            .key(.single(privateKey.publicKey))
+            .keyWithoutAlias(.single(privateKey.publicKey))
             .initialBalance(Hbar(10))
             .execute(testEnv.client)
             .getReceipt(testEnv.client)
@@ -230,7 +230,7 @@ internal class ScheduleCreate: XCTestCase {
         let privateKey = PrivateKey.generateEd25519()
 
         let accountId = try await AccountCreateTransaction()
-            .key(.single(privateKey.publicKey))
+            .keyWithoutAlias(.single(privateKey.publicKey))
             .initialBalance(Hbar(10))
             .execute(testEnv.client)
             .getReceipt(testEnv.client)
@@ -264,7 +264,7 @@ internal class ScheduleCreate: XCTestCase {
         let privateKey = PrivateKey.generateEd25519()
 
         let accountId = try await AccountCreateTransaction()
-            .key(.single(privateKey.publicKey))
+            .keyWithoutAlias(.single(privateKey.publicKey))
             .initialBalance(Hbar(10))
             .execute(testEnv.client)
             .getReceipt(testEnv.client)
@@ -298,7 +298,7 @@ internal class ScheduleCreate: XCTestCase {
         let privateKey = PrivateKey.generateEd25519()
 
         let accountId = try await AccountCreateTransaction()
-            .key(.single(privateKey.publicKey))
+            .keyWithoutAlias(.single(privateKey.publicKey))
             .initialBalance(Hbar(10))
             .execute(testEnv.client)
             .getReceipt(testEnv.client)
@@ -353,7 +353,7 @@ internal class ScheduleCreate: XCTestCase {
             threshold: 2)
 
         let accountId = try await AccountCreateTransaction()
-            .key(.keyList(keyList))
+            .keyWithoutAlias(.keyList(keyList))
             .initialBalance(Hbar(10))
             .execute(testEnv.client)
             .getReceipt(testEnv.client)
@@ -430,7 +430,7 @@ internal class ScheduleCreate: XCTestCase {
             threshold: 2)
 
         let accountId = try await AccountCreateTransaction()
-            .key(.keyList(keyList))
+            .keyWithoutAlias(.keyList(keyList))
             .initialBalance(Hbar(10))
             .execute(testEnv.client)
             .getReceipt(testEnv.client)

--- a/Tests/HieroE2ETests/Schedule/ScheduleInfo.swift
+++ b/Tests/HieroE2ETests/Schedule/ScheduleInfo.swift
@@ -28,7 +28,7 @@ internal class ScheduleInfo: XCTestCase {
 
     //     let key = PrivateKey.generateEd25519()
 
-    //     let transaction = AccountCreateTransaction().key(.single(key.publicKey))
+    //     let transaction = AccountCreateTransaction().keyWithoutAlias(.single(key.publicKey))
 
     //     let receipt = try await ScheduleCreateTransaction()
     //         .scheduledTransaction(transaction)

--- a/Tests/HieroE2ETests/Schedule/ScheduleSign.swift
+++ b/Tests/HieroE2ETests/Schedule/ScheduleSign.swift
@@ -33,7 +33,7 @@ internal final class ScheduleSign: XCTestCase {
 
         // Create a new account with keylist
         let accountReceipt = try await AccountCreateTransaction()
-            .key(.keyList(keyList))
+            .keyWithoutAlias(.keyList(keyList))
             .initialBalance(Hbar(1))
             .execute(testEnv.client)
             .getReceipt(testEnv.client)
@@ -87,7 +87,7 @@ internal final class ScheduleSign: XCTestCase {
 
         // Create new account with key list
         let accountReceipt = try await AccountCreateTransaction()
-            .key(.keyList(keyList))
+            .keyWithoutAlias(.keyList(keyList))
             .initialBalance(Hbar(1))
             .execute(testEnv.client)
             .getReceipt(testEnv.client)

--- a/Tests/HieroE2ETests/Token/TokenAirdrop.swift
+++ b/Tests/HieroE2ETests/Token/TokenAirdrop.swift
@@ -268,7 +268,7 @@ internal class TokenAirdrop: XCTestCase {
         // Create a receiver account with unlimited auto associations and receiverSig = true
         let receiverKey = PrivateKey.generateEd25519()
         let receiverAccountId = try await AccountCreateTransaction()
-            .key(Key.single(receiverKey.publicKey))
+            .keyWithoutAlias(Key.single(receiverKey.publicKey))
             .initialBalance(Hbar(1))
             .receiverSignatureRequired(true)
             .maxAutomaticTokenAssociations(-1)
@@ -304,7 +304,7 @@ internal class TokenAirdrop: XCTestCase {
         // Create a receiver account with unlimited auto associations and receiverSig = true
         let receiverKey = PrivateKey.generateEd25519()
         let receiverAccountId = try await AccountCreateTransaction()
-            .key(Key.single(receiverKey.publicKey))
+            .keyWithoutAlias(Key.single(receiverKey.publicKey))
             .initialBalance(Hbar(1))
             .receiverSignatureRequired(true)
             .maxAutomaticTokenAssociations(-1)

--- a/Tests/HieroE2ETests/Token/TokenReject.swift
+++ b/Tests/HieroE2ETests/Token/TokenReject.swift
@@ -378,7 +378,7 @@ internal class TokenReject: XCTestCase {
 
         let spenderAccountKey = PrivateKey.generateEd25519()
         let spenderCreateReceipt = try await AccountCreateTransaction()
-            .key(.single(spenderAccountKey.publicKey))
+            .keyWithoutAlias(.single(spenderAccountKey.publicKey))
             .initialBalance(Hbar(1))
             .maxAutomaticTokenAssociations(-1)
             .execute(testEnv.client)

--- a/Tests/HieroTests/__Snapshots__/AccountCreateTransactionTests/testSerialize.1.txt
+++ b/Tests/HieroTests/__Snapshots__/AccountCreateTransactionTests/testSerialize.1.txt
@@ -26,5 +26,5 @@ cryptoCreateAccount {
   memo: "fresh water"
   max_automatic_token_associations: 101
   staked_node_id: 4
-  alias: "0x000000000000000000"
+  alias: "\\V.\220\376\257\016\353\323>\247]!\002O$\235E\024\027"
 }

--- a/Tests/HieroTests/__Snapshots__/AccountCreateTransactionTests/testSerialize2.1.txt
+++ b/Tests/HieroTests/__Snapshots__/AccountCreateTransactionTests/testSerialize2.1.txt
@@ -26,4 +26,5 @@ cryptoCreateAccount {
   memo: "fresh water"
   max_automatic_token_associations: 101
   staked_node_id: 4
+  alias: "\342a\342j\354\316R\263x\217\254\226%\211o\373\306\273D$"
 }


### PR DESCRIPTION
Signed-off-by: Ricky Saechao <ricky@launchbadge.com>**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
- Add AccountCreateTransaction methods, `keyWithAlias` & `keyWithoutAlias`


**Related issue(s)**:
- https://github.com/hiero-ledger/hiero-sdk-swift/issues/429


Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
