### PR TITLE
feat: set `autoRenewAccountId` for new topic to fee payer

### DIFF
--- a/Sources/Hiero/Topic/TopicCreateTransaction.swift
+++ b/Sources/Hiero/Topic/TopicCreateTransaction.swift
@@ -30,16 +30,18 @@ public final class TopicCreateTransaction: Transaction {
         try super.init(protobuf: proto)
     }
 
+    @discardableResult
     public override func freezeWith(_ client: Client?) throws -> Self {
-        if let client = client {
-            if self.autoRenewAccountId == nil {
-                self.autoRenewAccountId = transactionId?.accountId ?? client.operator?.accountId
+        if self.autoRenewAccountId == nil {
+            if let feePayerAccountId = transactionId?.accountId {
+                self.autoRenewAccountId = feePayerAccountId
+            }
+            if let client = client, let clientOperatorAccountId = client.operator?.accountId {
+                self.autoRenewAccountId = clientOperatorAccountId
             }
         }
 
-        try super.freezeWith(client)
-
-        return self
+        return try super.freezeWith(client)
     }
 
     /// Short publicly visible memo about the topic. No guarantee of uniqueness.

--- a/Tests/HieroTests/TopicCreateTransactionTests.swift
+++ b/Tests/HieroTests/TopicCreateTransactionTests.swift
@@ -84,4 +84,12 @@ internal final class TopicCreateTransactionTests: XCTestCase {
 
         XCTAssertEqual(tx.autoRenewPeriod, Self.testAutoRenewPeriod)
     }
+
+    internal func testAutomaticallySetAutoRenewAccountId() throws {
+        let tx = TopicCreateTransaction()
+        tx.transactionId(Resources.txId)
+        try tx.freezeWith(nil)
+
+        XCTAssertEqual(tx.autoRenewAccountId, Resources.txId.accountId)
+    }
 }


### PR DESCRIPTION
**Description**:
This PR enables HIP-1021 and properly sets the `autoRenewAccountId` of a created topic to the fee payer.

**Related issue(s)**:

Fixes #440 
