### PR TITLE
chore: deprecate EthereumFlow

### DIFF
--- a/Sources/Hiero/Ethereum/EthereumFlow.swift
+++ b/Sources/Hiero/Ethereum/EthereumFlow.swift
@@ -3,6 +3,7 @@
 import Foundation
 
 /// Flow for executing ethereum transactions.
+@available(*, deprecated, message: "Use EthereumTransaction instead")
 public final class EthereumFlow {
     private static let maxEthereumDataSize: Int = 5120
 

--- a/Sources/Hiero/Version.swift
+++ b/Sources/Hiero/Version.swift
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 public enum VersionInfo {
-    public static let version = "v0.41.0-1-gf0db826"
+    public static let version = "v0.41.0-2-geadb0cb"
 }


### PR DESCRIPTION
**Description**:
This PR deprecates `EthereumFlow`, as `EthereumTransaction` can now deal with large files.

**Related issue(s)**:

Fixes #476 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
