### PR TITLE
fix: mirror node grpc connection issue and test forMirrorNetwork

### DIFF
--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -122,14 +122,21 @@ public final class Client: Sendable {
     }
 
     /// Set up the client from selected mirror network.
-    public static func forMirrorNetwork(_ mirrorNetworks: [String], shard: UInt64 = 0, realm: UInt64 = 0) async throws
-        -> Self
-    {
+    public static func forMirrorNetwork(
+        _ mirrorNetworks: [String],
+        shard: UInt64 = 0,
+        realm: UInt64 = 0
+    ) async throws -> Self {
         let eventLoop = PlatformSupport.makeEventLoopGroup(loopCount: 1)
+
         let client = Self(
             network: .init(
                 primary: try .init(addresses: [:], eventLoop: eventLoop.next()),
-                mirror: .init(targets: mirrorNetworks, eventLoop: eventLoop)
+                mirror: MirrorNetwork(
+                    targets: mirrorNetworks,
+                    eventLoop: eventLoop,
+                    transportSecurity: .plaintext
+                )
             ),
             ledgerId: nil,
             eventLoop,
@@ -232,7 +239,7 @@ public final class Client: Sendable {
             let eventLoop = PlatformSupport.makeEventLoopGroup(loopCount: 1)
 
             let client = try Client.forNetwork(network)
-            client.setMirrorNetwork(["127.0.0.1:5600"])
+            client.mirrorNet = MirrorNetwork.localhost(eventLoop)
 
             return Self(
                 network: client.networkInner,


### PR DESCRIPTION
**Description**:
This PR fixes an issue with `NodeAddressBookQuery` where it was unable to connect with solo. The cause of this is because it was using a TLS connection when solo is only using plaintext. So now localhost connections default to plaintext. This also adjusts node addressing and tests `forMirrorNetwork` against solo and is confirmed working.

**Related issue(s)**:

Fixes #443 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
