### PR TITLE
feat: add max_custom_fee limits for scheduled transactions

### DIFF
--- a/Sources/Hiero/Schedule/ScheduleCreateTransaction.swift
+++ b/Sources/Hiero/Schedule/ScheduleCreateTransaction.swift
@@ -171,6 +171,7 @@ extension ScheduleCreateTransaction: ToProtobuf {
             Proto_SchedulableTransactionBody.with { proto in
                 proto.data = scheduledTransaction.toSchedulableTransactionData()
                 proto.memo = scheduledTransaction.transaction.transactionMemo
+                proto.maxCustomFees = scheduledTransaction.transaction.customFeeLimits.compactMap { $0.toProtobuf() }
 
                 let transactionFee =
                     scheduledTransaction.transaction.maxTransactionFee

--- a/Sources/HieroProtobufs/Generated/services/contract_types.pb.swift
+++ b/Sources/HieroProtobufs/Generated/services/contract_types.pb.swift
@@ -56,7 +56,7 @@ public struct Proto_InternalCallContext: @unchecked Sendable {
 }
 
 ///*
-/// Results of executing EVM transaction.<br/>
+/// Results of executing a EVM transaction.<br/>
 public struct Proto_EvmTransactionResult: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -99,7 +99,8 @@ public struct Proto_EvmTransactionResult: @unchecked Sendable {
   public var gasUsed: UInt64 = 0
 
   ///*
-  /// If not already externalized, the context of the internal call producing this result.
+  /// If not already externalized in a transaction body, the context of the
+  /// internal call producing this result.
   public var internalCallContext: Proto_InternalCallContext {
     get {return _internalCallContext ?? Proto_InternalCallContext()}
     set {_internalCallContext = newValue}

--- a/Sources/HieroProtobufs/Generated/services/node_update.pb.swift
+++ b/Sources/HieroProtobufs/Generated/services/node_update.pb.swift
@@ -208,7 +208,9 @@ public struct Com_Hedera_Hapi_Node_Addressbook_NodeUpdateTransactionBody: Sendab
   /// This endpoint MUST use a valid port and SHALL be reachable over TLS.<br/>
   /// This field MAY be omitted if the node does not support gRPC-Web access.<br/>
   /// This field MUST be updated if the gRPC-Web endpoint changes.<br/>
-  /// This field SHALL enable frontend clients to avoid hard-coded proxy endpoints.
+  /// This field SHALL enable frontend clients to avoid hard-coded proxy endpoints.<br/>
+  /// This field MAY be set to `ServiceEndpoint.DEFAULT` to remove a previously-valid
+  /// web proxy.
   public var grpcProxyEndpoint: Proto_ServiceEndpoint {
     get {return _grpcProxyEndpoint ?? Proto_ServiceEndpoint()}
     set {_grpcProxyEndpoint = newValue}

--- a/Sources/HieroProtobufs/Generated/services/response_code.pb.swift
+++ b/Sources/HieroProtobufs/Generated/services/response_code.pb.swift
@@ -1546,6 +1546,10 @@ public enum Proto_ResponseCodeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
   /// The GRPC proxy endpoint is set in the NodeCreate or NodeUpdate transaction,
   /// which the network does not support.
   case grpcWebProxyNotSupported // = 399
+
+  ///*
+  /// An NFT transfers list referenced a token type other than NON_FUNGIBLE_UNIQUE.
+  case nftTransfersOnlyAllowedForNonFungibleUnique // = 400
   case UNRECOGNIZED(Int)
 
   public init() {
@@ -1912,6 +1916,7 @@ public enum Proto_ResponseCodeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
     case 397: self = .throttleGroupLcmOverflow
     case 398: self = .airdropContainsMultipleSendersForAToken
     case 399: self = .grpcWebProxyNotSupported
+    case 400: self = .nftTransfersOnlyAllowedForNonFungibleUnique
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
@@ -2276,6 +2281,7 @@ public enum Proto_ResponseCodeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
     case .throttleGroupLcmOverflow: return 397
     case .airdropContainsMultipleSendersForAToken: return 398
     case .grpcWebProxyNotSupported: return 399
+    case .nftTransfersOnlyAllowedForNonFungibleUnique: return 400
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -2640,6 +2646,7 @@ public enum Proto_ResponseCodeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
     .throttleGroupLcmOverflow,
     .airdropContainsMultipleSendersForAToken,
     .grpcWebProxyNotSupported,
+    .nftTransfersOnlyAllowedForNonFungibleUnique,
   ]
 
 }
@@ -3006,5 +3013,6 @@ extension Proto_ResponseCodeEnum: SwiftProtobuf._ProtoNameProviding {
     397: .same(proto: "THROTTLE_GROUP_LCM_OVERFLOW"),
     398: .same(proto: "AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN"),
     399: .same(proto: "GRPC_WEB_PROXY_NOT_SUPPORTED"),
+    400: .same(proto: "NFT_TRANSFERS_ONLY_ALLOWED_FOR_NON_FUNGIBLE_UNIQUE"),
   ]
 }

--- a/Sources/HieroProtobufs/Generated/services/schedulable_transaction_body.pb.swift
+++ b/Sources/HieroProtobufs/Generated/services/schedulable_transaction_body.pb.swift
@@ -602,6 +602,17 @@ public struct Proto_SchedulableTransactionBody: @unchecked Sendable {
     set {_uniqueStorage()._data = .tokenAirdrop(newValue)}
   }
 
+  ///*
+  /// A list of maximum custom fees that the users are willing to pay.
+  /// <p>
+  /// This field is OPTIONAL.<br/>
+  /// If left empty, the users are accepting to pay any custom fee.<br/>
+  /// If used with a transaction type that does not support custom fee limits, the transaction will fail.
+  public var maxCustomFees: [Proto_CustomFeeLimit] {
+    get {return _storage._maxCustomFees}
+    set {_uniqueStorage()._maxCustomFees = newValue}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_Data: Equatable, Sendable {
@@ -878,12 +889,14 @@ extension Proto_SchedulableTransactionBody: SwiftProtobuf.Message, SwiftProtobuf
     46: .same(proto: "tokenCancelAirdrop"),
     47: .same(proto: "tokenClaimAirdrop"),
     48: .same(proto: "tokenAirdrop"),
+    1001: .standard(proto: "max_custom_fees"),
   ]
 
   fileprivate class _StorageClass {
     var _transactionFee: UInt64 = 0
     var _memo: String = String()
     var _data: Proto_SchedulableTransactionBody.OneOf_Data?
+    var _maxCustomFees: [Proto_CustomFeeLimit] = []
 
     #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
@@ -901,6 +914,7 @@ extension Proto_SchedulableTransactionBody: SwiftProtobuf.Message, SwiftProtobuf
       _transactionFee = source._transactionFee
       _memo = source._memo
       _data = source._data
+      _maxCustomFees = source._maxCustomFees
     }
   }
 
@@ -1519,6 +1533,7 @@ extension Proto_SchedulableTransactionBody: SwiftProtobuf.Message, SwiftProtobuf
             _storage._data = .tokenAirdrop(v)
           }
         }()
+        case 1001: try { try decoder.decodeRepeatedMessageField(value: &_storage._maxCustomFees) }()
         default: break
         }
       }
@@ -1724,6 +1739,9 @@ extension Proto_SchedulableTransactionBody: SwiftProtobuf.Message, SwiftProtobuf
       }()
       case nil: break
       }
+      if !_storage._maxCustomFees.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._maxCustomFees, fieldNumber: 1001)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1736,6 +1754,7 @@ extension Proto_SchedulableTransactionBody: SwiftProtobuf.Message, SwiftProtobuf
         if _storage._transactionFee != rhs_storage._transactionFee {return false}
         if _storage._memo != rhs_storage._memo {return false}
         if _storage._data != rhs_storage._data {return false}
+        if _storage._maxCustomFees != rhs_storage._maxCustomFees {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Sources/HieroProtobufs/Protos/services/contract_types.proto
+++ b/Sources/HieroProtobufs/Protos/services/contract_types.proto
@@ -42,7 +42,7 @@ message InternalCallContext {
 }
 
 /**
- * Results of executing EVM transaction.<br/>
+ * Results of executing a EVM transaction.<br/>
  */
 message EvmTransactionResult {
     /**
@@ -73,7 +73,8 @@ message EvmTransactionResult {
     uint64 gas_used = 5;
 
     /**
-     * If not already externalized, the context of the internal call producing this result.
+     * If not already externalized in a transaction body, the context of the
+     * internal call producing this result.
      */
     InternalCallContext internal_call_context = 6;
 }

--- a/Sources/HieroProtobufs/Protos/services/node_update.proto
+++ b/Sources/HieroProtobufs/Protos/services/node_update.proto
@@ -162,7 +162,9 @@ message NodeUpdateTransactionBody {
      * This endpoint MUST use a valid port and SHALL be reachable over TLS.<br/>
      * This field MAY be omitted if the node does not support gRPC-Web access.<br/>
      * This field MUST be updated if the gRPC-Web endpoint changes.<br/>
-     * This field SHALL enable frontend clients to avoid hard-coded proxy endpoints.
+     * This field SHALL enable frontend clients to avoid hard-coded proxy endpoints.<br/>
+     * This field MAY be set to `ServiceEndpoint.DEFAULT` to remove a previously-valid
+     * web proxy.
      */
     proto.ServiceEndpoint grpc_proxy_endpoint = 10;
 }

--- a/Sources/HieroProtobufs/Protos/services/response_code.proto
+++ b/Sources/HieroProtobufs/Protos/services/response_code.proto
@@ -1760,4 +1760,9 @@ enum ResponseCodeEnum {
      * which the network does not support.
      */
     GRPC_WEB_PROXY_NOT_SUPPORTED = 399;
+
+    /**
+     * An NFT transfers list referenced a token type other than NON_FUNGIBLE_UNIQUE.
+     */
+    NFT_TRANSFERS_ONLY_ALLOWED_FOR_NON_FUNGIBLE_UNIQUE = 400;
 }

--- a/Sources/HieroProtobufs/Protos/services/schedulable_transaction_body.proto
+++ b/Sources/HieroProtobufs/Protos/services/schedulable_transaction_body.proto
@@ -70,6 +70,7 @@ import "services/token_airdrop.proto";
 
 import "services/schedule_delete.proto";
 import "services/util_prng.proto";
+import "services/custom_fees.proto";
 
 import "services/node_create.proto";
 import "services/node_update.proto";
@@ -403,4 +404,13 @@ message SchedulableTransactionBody {
          */
         TokenAirdropTransactionBody tokenAirdrop = 48;
     }
+
+    /**
+      * A list of maximum custom fees that the users are willing to pay.
+      * <p>
+      * This field is OPTIONAL.<br/>
+      * If left empty, the users are accepting to pay any custom fee.<br/>
+      * If used with a transaction type that does not support custom fee limits, the transaction will fail.
+      */
+    repeated CustomFeeLimit max_custom_fees = 1001;
 }

--- a/Tests/HieroTests/TopicMessageSubmitTransactionTests.swift
+++ b/Tests/HieroTests/TopicMessageSubmitTransactionTests.swift
@@ -24,7 +24,7 @@ internal final class TopicMessageSubmitTransactionTests: XCTestCase {
     internal func testSerialize() throws {
         let tx = try Self.makeTransaction().makeProtoBody()
 
-        assertSnapshot(matching: tx, as: .description)
+        assertSnapshot(of: tx, as: .description)
     }
 
     internal func testToFromBytes() throws {
@@ -127,5 +127,28 @@ internal final class TopicMessageSubmitTransactionTests: XCTestCase {
             .addCustomFeeLimit(customFeeLimitToAdd)
 
         XCTAssertEqual(tx.customFeeLimits, [customFeeLimitToAdd])
+    }
+
+    internal func testScheduledCustomFeeLimits() throws {
+        let payerId = AccountId(3)
+        let amount: UInt64 = 4
+        let tokenId = TokenId(3)
+        let customFeeLimitToAdd = CustomFeeLimit(
+            payerId: payerId,
+            customFees: [
+                CustomFixedFee(amount, nil, tokenId)
+            ])
+
+        let tx = TopicMessageSubmitTransaction()
+            .addCustomFeeLimit(customFeeLimitToAdd)
+            .schedule()
+            .toProtobuf()
+
+        XCTAssertEqual(tx.scheduledTransactionBody.maxCustomFees.count, 1)
+        XCTAssertEqual(tx.scheduledTransactionBody.maxCustomFees[0].accountID.accountNum, Int64(payerId.num))
+        XCTAssertEqual(tx.scheduledTransactionBody.maxCustomFees[0].fees.count, 1)
+        XCTAssertEqual(tx.scheduledTransactionBody.maxCustomFees[0].fees[0].amount, Int64(amount))
+        XCTAssertEqual(tx.scheduledTransactionBody.maxCustomFees[0].fees[0].denominatingTokenID.tokenNum, Int64(tokenId.num))
+
     }
 }


### PR DESCRIPTION
**Description**:
This PR adds the `max_custom_fee` limits for scheduled transactions. Still waiting to be e2e tested

**Related issue(s)**:

Fixes #482 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
