### PR TITLE
feat: add receipt node failover support and related tests

### DIFF
--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -51,6 +51,9 @@ public final class Client: Sendable {
     /// Whether to regenerate transaction IDs on expiry
     private let _regenerateTransactionId: ManagedAtomic<Bool>
 
+    /// Whether receipt and record queries may fail over from the submitting node
+    private let _allowReceiptNodeFailover: ManagedAtomic<Bool>
+
     /// Maximum transaction fee in tinybars (0 = no limit)
     private let _maxTransactionFee: ManagedAtomic<Int64>
 
@@ -101,6 +104,7 @@ public final class Client: Sendable {
         self._ledgerId = .init(ledgerId)
         self._autoValidateChecksums = .init(false)  // Checksums disabled by default for performance
         self._regenerateTransactionId = .init(true)  // Auto-regenerate expired transaction IDs by default
+        self._allowReceiptNodeFailover = .init(false)
         self._maxTransactionFee = .init(0)  // 0 = no fee limit (use network defaults)
         self.networkUpdateTask = NetworkUpdateTask(
             eventLoop: eventLoop,
@@ -548,6 +552,8 @@ public final class Client: Sendable {
             client._operator.withLockedValue { $0 = `operator` }
         }
 
+        client.allowReceiptNodeFailover = configData.allowReceiptNodeFailover
+
         return client
     }
 
@@ -755,6 +761,29 @@ public final class Client: Sendable {
         self.defaultRegenerateTransactionId = defaultRegenerateTransactionId
 
         return self
+    }
+
+    /// Whether receipt and record queries may advance from the submitting node to other nodes.
+    ///
+    /// The default is `false`, which keeps receipt and record queries pinned to the submitting
+    /// node. Enabling this is intended for high-throughput clients that accept the availability
+    /// tradeoff of trying other nodes when the submitting node is unavailable.
+    public var allowReceiptNodeFailover: Bool {
+        get { self._allowReceiptNodeFailover.load(ordering: .relaxed) }
+        set(value) { self._allowReceiptNodeFailover.store(value, ordering: .relaxed) }
+    }
+
+    /// Sets whether receipt and record queries may fail over from the submitting node.
+    @discardableResult
+    public func setAllowReceiptNodeFailover(_ allowReceiptNodeFailover: Bool) -> Self {
+        self.allowReceiptNodeFailover = allowReceiptNodeFailover
+
+        return self
+    }
+
+    /// Returns whether receipt and record query failover is enabled.
+    public func getAllowReceiptNodeFailover() -> Bool {
+        allowReceiptNodeFailover
     }
 
     // MARK: - Internal Helpers

--- a/Sources/Hiero/Client/ClientConfig.swift
+++ b/Sources/Hiero/Client/ClientConfig.swift
@@ -55,6 +55,9 @@ internal struct ClientConfig: Decodable {
     /// Realm number (default: 0)
     internal let realm: UInt64
 
+    /// Whether receipt and record queries may fail over from the submitting node
+    internal let allowReceiptNodeFailover: Bool
+
     // MARK: - Coding Keys
 
     private enum CodingKeys: CodingKey {
@@ -63,6 +66,7 @@ internal struct ClientConfig: Decodable {
         case mirrorNetwork
         case shard
         case realm
+        case allowReceiptNodeFailover
     }
 
     private enum OperatorKeys: CodingKey {
@@ -135,5 +139,7 @@ internal struct ClientConfig: Decodable {
         // Decode shard and realm (with defaults)
         shard = try container.decodeIfPresent(UInt64.self, forKey: .shard) ?? 0
         realm = try container.decodeIfPresent(UInt64.self, forKey: .realm) ?? 0
+        allowReceiptNodeFailover =
+            try container.decodeIfPresent(Bool.self, forKey: .allowReceiptNodeFailover) ?? false
     }
 }

--- a/Sources/Hiero/Ethereum/EthereumFlow.swift
+++ b/Sources/Hiero/Ethereum/EthereumFlow.swift
@@ -80,7 +80,7 @@ public final class EthereumFlow {
         let fileId = try await FileCreateTransaction()
             .contents(data.fileCreate)
             .execute(client, timeoutPerTansaction)
-            .getReceiptQuery()
+            .getReceiptQuery(client)
             .execute(client, timeoutPerTansaction)
             .fileId!
 

--- a/Sources/Hiero/Query.swift
+++ b/Sources/Hiero/Query.swift
@@ -160,7 +160,13 @@ public class Query<Response>: ValidateChecksums {
         if self.requiresPayment {
             // hack: this is a TransactionRecordQuery, which means we need to run the receipt first.
             if let relatedTransactionId = self.relatedTransactionId {
-                _ = try? await TransactionReceiptQuery().transactionId(relatedTransactionId).execute(client, timeout)
+                let receiptQuery = TransactionReceiptQuery().transactionId(relatedTransactionId)
+
+                if let nodeAccountIds = self.nodeAccountIds {
+                    receiptQuery.nodeAccountIds(nodeAccountIds)
+                }
+
+                _ = try? await receiptQuery.execute(client, timeout)
             }
 
             if self.payment.amount == nil {

--- a/Sources/Hiero/Token/TokenRejectFlow.swift
+++ b/Sources/Hiero/Token/TokenRejectFlow.swift
@@ -153,13 +153,13 @@ public final class TokenRejectFlow {
         let rejectResponse = try await makeTokenRejectTransaction(nodeAccountIds, tokenRejectData: tokenRejectData)
             .execute(client, timeoutPerTransaction)
 
-        _ = try await rejectResponse.getReceiptQuery().execute(client, timeoutPerTransaction)
+        _ = try await rejectResponse.getReceiptQuery(client).execute(client, timeoutPerTransaction)
 
         let dissociateResponse = try await makeTokenDissociateTransaction(
             nodeAccountIds, tokenRejectData: tokenRejectData
         ).execute(client, timeoutPerTransaction)
 
-        _ = try await dissociateResponse.getReceiptQuery().execute(client, timeoutPerTransaction)
+        _ = try await dissociateResponse.getReceiptQuery(client).execute(client, timeoutPerTransaction)
 
         return rejectResponse
     }

--- a/Sources/Hiero/Transaction.swift
+++ b/Sources/Hiero/Transaction.swift
@@ -29,6 +29,9 @@ public class Transaction: ValidateChecksums {
         2
     }
 
+    internal private(set) final var nodeAccountIdsExplicit: Bool = false
+    private final var settingAutomaticNodeAccountIds: Bool = false
+
     internal static let dummyAccountId = AccountId(0)
     internal static let dummyId = TransactionId.withValidStart(
         dummyAccountId, Timestamp(fromUnixTimestampNanos: 0))
@@ -46,6 +49,14 @@ public class Transaction: ValidateChecksums {
     public final var nodeAccountIds: [AccountId]? {
         willSet {
             ensureNotFrozen(fieldName: "nodeAccountIds")
+        }
+
+        didSet {
+            guard !settingAutomaticNodeAccountIds else {
+                return
+            }
+
+            nodeAccountIdsExplicit = nodeAccountIds != nil
         }
     }
 
@@ -467,6 +478,8 @@ public class Transaction: ValidateChecksums {
             }
 
             self.`operator` = client.operator
+            self.settingAutomaticNodeAccountIds = true
+            defer { self.settingAutomaticNodeAccountIds = false }
             self.nodeAccountIds = client.consensus.selectHealthyNodeSample()
         }
 
@@ -688,7 +701,11 @@ extension Transaction {
         _ transactionId: TransactionId?
     ) -> Response {
         return TransactionResponse(
-            nodeAccountId: nodeAccountId, transactionId: transactionId!, transactionHash: context)
+            nodeAccountId: nodeAccountId,
+            transactionId: transactionId!,
+            transactionHash: context,
+            transactionNodeAccountIds: nodeAccountIdsExplicit ? nodeAccountIds : nil
+        )
     }
 
     internal final func makeErrorPrecheck(_ status: Status, _ transactionId: TransactionId?) -> HError {

--- a/Sources/Hiero/Transaction/TransactionSources.swift
+++ b/Sources/Hiero/Transaction/TransactionSources.swift
@@ -437,10 +437,15 @@ extension SourceTransactionExecuteView: Execute {
     }
 
     internal func makeResponse(
-        _ response: GrpcResponse, _ context: TransactionHash, _ nodeAccountId: AccountId,
+        _: GrpcResponse, _ context: TransactionHash, _ nodeAccountId: AccountId,
         _ transactionId: TransactionId?
     ) -> Response {
-        inner.makeResponse(response, context, nodeAccountId, transactionId)
+        TransactionResponse(
+            nodeAccountId: nodeAccountId,
+            transactionId: transactionId!,
+            transactionHash: context,
+            transactionNodeAccountIds: chunk.nodeIds
+        )
     }
 
     internal func makeErrorPrecheck(_ status: Status, _ transactionId: TransactionId?) -> HError {

--- a/Sources/Hiero/TransactionResponse.swift
+++ b/Sources/Hiero/TransactionResponse.swift
@@ -24,8 +24,23 @@ public struct TransactionResponse: Sendable {
     /// This can be used to lookup the transaction in an explorer.
     public let transactionHash: TransactionHash
 
+    /// Transaction-specific node account IDs, when explicitly configured on the transaction.
+    internal let transactionNodeAccountIds: [AccountId]?
+
     /// Whether the receipt/record status should be validated.
     public var validateStatus: Bool = true
+
+    internal init(
+        nodeAccountId: AccountId,
+        transactionId: TransactionId,
+        transactionHash: TransactionHash,
+        transactionNodeAccountIds: [AccountId]? = nil
+    ) {
+        self.nodeAccountId = nodeAccountId
+        self.transactionId = transactionId
+        self.transactionHash = transactionHash
+        self.transactionNodeAccountIds = transactionNodeAccountIds
+    }
 
     /// Whether the receipt/record status should be validated.
     @discardableResult
@@ -41,14 +56,14 @@ public struct TransactionResponse: Sendable {
     ///
     /// - Throws: an error of type ``HError``.
     public func getReceipt(_ client: Client, _ timeout: TimeInterval? = nil) async throws -> TransactionReceipt {
-        try await getReceiptQuery().execute(client, timeout)
+        try await getReceiptQuery(client).execute(client, timeout)
     }
 
     /// Returns a query that when executed, returns the receipt for the associated transaction.
-    public func getReceiptQuery() -> TransactionReceiptQuery {
+    public func getReceiptQuery(_ client: Client? = nil) -> TransactionReceiptQuery {
         TransactionReceiptQuery()
             .transactionId(transactionId)
-            .nodeAccountIds([nodeAccountId])
+            .nodeAccountIds(receiptNodeAccountIds(client))
             .validateStatus(validateStatus)
     }
 
@@ -58,14 +73,37 @@ public struct TransactionResponse: Sendable {
     ///
     /// - Throws: an error of type ``HError``.
     public func getRecord(_ client: Client, _ timeout: TimeInterval? = nil) async throws -> TransactionRecord {
-        try await getRecordQuery().execute(client, timeout)
+        try await getRecordQuery(client).execute(client, timeout)
     }
 
     /// Returns a query that when executed, returns the record for the associated transaction.
-    public func getRecordQuery() -> TransactionRecordQuery {
+    public func getRecordQuery(_ client: Client? = nil) -> TransactionRecordQuery {
         TransactionRecordQuery()
             .transactionId(transactionId)
-            .nodeAccountIds([nodeAccountId])
+            .nodeAccountIds(receiptNodeAccountIds(client))
             .validateStatus(validateStatus)
+    }
+
+    private func receiptNodeAccountIds(_ client: Client?) -> [AccountId] {
+        guard client?.allowReceiptNodeFailover == true else {
+            return [nodeAccountId]
+        }
+
+        let fallbackNodeAccountIds = transactionNodeAccountIds ?? client?.consensus.nodes ?? []
+        return [nodeAccountId].appendingUnique(fallbackNodeAccountIds)
+    }
+}
+
+extension Array where Element == AccountId {
+    fileprivate func appendingUnique(_ accountIds: [AccountId]) -> [AccountId] {
+        var seen = Set(self)
+        var result = self
+        result.reserveCapacity(self.count + accountIds.count)
+
+        for accountId in accountIds where seen.insert(accountId).inserted {
+            result.append(accountId)
+        }
+
+        return result
     }
 }

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -341,6 +341,39 @@ internal final class ClientUnitTests: HieroUnitTestCase {
         }
     }
 
+    // MARK: - Receipt Node Failover Tests
+
+    internal func test_AllowReceiptNodeFailoverDefaultsToFalse() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        XCTAssertFalse(client.allowReceiptNodeFailover)
+        XCTAssertFalse(client.getAllowReceiptNodeFailover())
+    }
+
+    internal func test_SetAllowReceiptNodeFailoverStoresValue() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        let returnedClient = client.setAllowReceiptNodeFailover(true)
+
+        XCTAssertTrue(client.allowReceiptNodeFailover)
+        XCTAssertTrue(client.getAllowReceiptNodeFailover())
+        XCTAssertTrue(client === returnedClient)
+    }
+
+    internal func test_AllowReceiptNodeFailoverCanBeSetFromConfig() throws {
+        let client = try Client.fromConfig(
+            """
+            {
+                "network": "localhost",
+                "mirrorNetwork": "localhost",
+                "allowReceiptNodeFailover": true
+            }
+            """
+        )
+
+        XCTAssertTrue(client.allowReceiptNodeFailover)
+    }
+
     // MARK: - Operator Tests
 
     internal func test_GetOperatorAccountIdReturnsNilWhenNotSet() throws {

--- a/Tests/HieroUnitTests/TransactionResponseUnitTests.swift
+++ b/Tests/HieroUnitTests/TransactionResponseUnitTests.swift
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+import HieroTestSupport
+import XCTest
+
+@testable import Hiero
+
+internal final class TransactionResponseUnitTests: HieroUnitTestCase {
+    private let submittingNode = AccountId(num: 5006)
+    private let otherNode = AccountId(num: 5005)
+    private let thirdNode = AccountId(num: 5007)
+
+    private func makeClient() throws -> Client {
+        try Client.forNetwork([
+            "127.0.0.1:50211": otherNode,
+            "127.0.0.1:50212": submittingNode,
+            "127.0.0.1:50213": thirdNode,
+        ])
+    }
+
+    private func makeResponse(transactionNodeAccountIds: [AccountId]? = nil) -> TransactionResponse {
+        TransactionResponse(
+            nodeAccountId: submittingNode,
+            transactionId: TestConstants.transactionId,
+            transactionHash: TransactionHash(hashing: Data([1, 2, 3])),
+            transactionNodeAccountIds: transactionNodeAccountIds
+        )
+    }
+
+    internal func test_GetReceiptAndRecordQueriesArePinnedByDefault() throws {
+        let client = try makeClient()
+        let response = makeResponse(transactionNodeAccountIds: [otherNode, submittingNode, thirdNode])
+
+        XCTAssertEqual(response.getReceiptQuery(client).nodeAccountIds, [submittingNode])
+        XCTAssertEqual(response.getRecordQuery(client).nodeAccountIds, [submittingNode])
+    }
+
+    internal func test_GetReceiptAndRecordQueriesArePinnedWithoutClient() throws {
+        let client = try makeClient()
+        client.allowReceiptNodeFailover = true
+        let response = makeResponse(transactionNodeAccountIds: [otherNode, submittingNode, thirdNode])
+
+        XCTAssertEqual(response.getReceiptQuery().nodeAccountIds, [submittingNode])
+        XCTAssertEqual(response.getRecordQuery().nodeAccountIds, [submittingNode])
+    }
+
+    internal func test_GetReceiptAndRecordQueriesUseExplicitTransactionNodesWhenFailoverEnabled() throws {
+        let client = try makeClient()
+        client.allowReceiptNodeFailover = true
+        let response = makeResponse(transactionNodeAccountIds: [otherNode, submittingNode, thirdNode, otherNode])
+
+        XCTAssertEqual(response.getReceiptQuery(client).nodeAccountIds, [submittingNode, otherNode, thirdNode])
+        XCTAssertEqual(response.getRecordQuery(client).nodeAccountIds, [submittingNode, otherNode, thirdNode])
+    }
+
+    internal func test_GetReceiptAndRecordQueriesUseClientNetworkWhenFailoverEnabledWithoutExplicitNodes() throws {
+        let client = try makeClient()
+        client.allowReceiptNodeFailover = true
+        let response = makeResponse()
+
+        let expected = uniqueNodeAccountIds([submittingNode] + client.consensus.nodes)
+
+        XCTAssertEqual(response.getReceiptQuery(client).nodeAccountIds, expected)
+        XCTAssertEqual(response.getRecordQuery(client).nodeAccountIds, expected)
+    }
+
+    internal func test_TransactionResponseKeepsExplicitTransactionNodes() throws {
+        let client = try makeClient()
+        client.allowReceiptNodeFailover = true
+        let transaction = Transaction().nodeAccountIds([otherNode, submittingNode])
+
+        let response = transaction.makeResponse(
+            Proto_TransactionResponse(),
+            TransactionHash(hashing: Data([4, 5, 6])),
+            submittingNode,
+            TestConstants.transactionId
+        )
+
+        XCTAssertEqual(response.getReceiptQuery(client).nodeAccountIds, [submittingNode, otherNode])
+    }
+
+    internal func test_TransactionResponseFallsBackToClientNetworkWithoutExplicitTransactionNodes() throws {
+        let client = try makeClient()
+        client.allowReceiptNodeFailover = true
+        let transaction = Transaction()
+
+        let response = transaction.makeResponse(
+            Proto_TransactionResponse(),
+            TransactionHash(hashing: Data([4, 5, 6])),
+            submittingNode,
+            TestConstants.transactionId
+        )
+
+        XCTAssertEqual(
+            response.getReceiptQuery(client).nodeAccountIds,
+            uniqueNodeAccountIds([submittingNode] + client.consensus.nodes)
+        )
+    }
+
+    private func uniqueNodeAccountIds(_ nodeAccountIds: [AccountId]) -> [AccountId] {
+        var seen: Set<AccountId> = []
+        var result: [AccountId] = []
+
+        for nodeAccountId in nodeAccountIds where seen.insert(nodeAccountId).inserted {
+            result.append(nodeAccountId)
+        }
+
+        return result
+    }
+}

--- a/Tests/HieroUnitTests/TransactionUnitTests.swift
+++ b/Tests/HieroUnitTests/TransactionUnitTests.swift
@@ -33,6 +33,7 @@ internal final class TransactionUnitTests: HieroUnitTestCase {
         let rhs2 = tx2.nodeAccountIds
 
         XCTAssertEqual(lhs1, rhs2)
+        
         XCTAssertEqual(tx.transactionId, tx2.transactionId)
         XCTAssertEqual(tx.transactionMemo, tx2.transactionMemo)
         XCTAssertEqual(tx.transactionValidDuration, tx2.transactionValidDuration)

--- a/Tests/HieroUnitTests/TransactionUnitTests.swift
+++ b/Tests/HieroUnitTests/TransactionUnitTests.swift
@@ -33,7 +33,7 @@ internal final class TransactionUnitTests: HieroUnitTestCase {
         let rhs2 = tx2.nodeAccountIds
 
         XCTAssertEqual(lhs1, rhs2)
-        
+
         XCTAssertEqual(tx.transactionId, tx2.transactionId)
         XCTAssertEqual(tx.transactionMemo, tx2.transactionMemo)
         XCTAssertEqual(tx.transactionValidDuration, tx2.transactionValidDuration)

--- a/Tests/HieroUnitTests/TransactionUnitTests.swift
+++ b/Tests/HieroUnitTests/TransactionUnitTests.swift
@@ -33,7 +33,6 @@ internal final class TransactionUnitTests: HieroUnitTestCase {
         let rhs2 = tx2.nodeAccountIds
 
         XCTAssertEqual(lhs1, rhs2)
-
         XCTAssertEqual(tx.transactionId, tx2.transactionId)
         XCTAssertEqual(tx.transactionMemo, tx2.transactionMemo)
         XCTAssertEqual(tx.transactionValidDuration, tx2.transactionValidDuration)


### PR DESCRIPTION
**Description**:
This pull request introduces a new feature to support failover for transaction receipt and record queries, allowing them to be retried on nodes other than the original submitting node. This is controlled by a new `allowReceiptNodeFailover` setting in the `Client`, which defaults to `false` for backward compatibility. The implementation tracks explicit node account IDs per transaction, updates the construction of receipt/record queries, and adds comprehensive tests for the new behavior.

The most important changes are:

**Receipt/Record Query Failover Support:**
* Added `allowReceiptNodeFailover` property and related methods to `Client`, including configuration, getter/setter, and propagation from config files. When enabled, receipt and record queries will use all relevant nodes, not just the submitting node. (`Sources/Hiero/Client/Client.swift` [[1]](diffhunk://#diff-b8218ee329547bda3d2518a5d9a007b4e8bbb4549b2bdd5c224b9c578571ba6aR54-R56) [[2]](diffhunk://#diff-b8218ee329547bda3d2518a5d9a007b4e8bbb4549b2bdd5c224b9c578571ba6aR107) [[3]](diffhunk://#diff-b8218ee329547bda3d2518a5d9a007b4e8bbb4549b2bdd5c224b9c578571ba6aR555-R556) [[4]](diffhunk://#diff-b8218ee329547bda3d2518a5d9a007b4e8bbb4549b2bdd5c224b9c578571ba6aR766-R788); `Sources/Hiero/Client/ClientConfig.swift` [[5]](diffhunk://#diff-a1d0961d3d62e42226f9d3fd380ef501578ee49f0feead1dc05ce73ba294ad14R58-R60) [[6]](diffhunk://#diff-a1d0961d3d62e42226f9d3fd380ef501578ee49f0feead1dc05ce73ba294ad14R69) [[7]](diffhunk://#diff-a1d0961d3d62e42226f9d3fd380ef501578ee49f0feead1dc05ce73ba294ad14R142-R143)
* Updated `TransactionResponse` to track explicit transaction node account IDs and to construct receipt/record queries using the appropriate set of nodes based on the failover setting. (`Sources/Hiero/TransactionResponse.swift` [[1]](diffhunk://#diff-be81d711e0eddfbcfd5e2b282607fc5958dcb94f1d1d552b96413c3ab070a0f3R27-R44) [[2]](diffhunk://#diff-be81d711e0eddfbcfd5e2b282607fc5958dcb94f1d1d552b96413c3ab070a0f3L44-R66) [[3]](diffhunk://#diff-be81d711e0eddfbcfd5e2b282607fc5958dcb94f1d1d552b96413c3ab070a0f3L61-R108)

**Transaction and Response Construction:**
* Modified `Transaction` and `TransactionResponse` to propagate and track explicit node account IDs, ensuring correct node selection logic for failover. (`Sources/Hiero/Transaction.swift` [[1]](diffhunk://#diff-de6b2643de61c41046a711c74cf7df6b5aa97fc7afee0de5a0f852b17f13cc87R32-R34) [[2]](diffhunk://#diff-de6b2643de61c41046a711c74cf7df6b5aa97fc7afee0de5a0f852b17f13cc87R53-R60) [[3]](diffhunk://#diff-de6b2643de61c41046a711c74cf7df6b5aa97fc7afee0de5a0f852b17f13cc87R481-R482) [[4]](diffhunk://#diff-de6b2643de61c41046a711c74cf7df6b5aa97fc7afee0de5a0f852b17f13cc87L691-R708); `Sources/Hiero/Transaction/TransactionSources.swift` [[5]](diffhunk://#diff-0b57246b3034294c2228cfb047f86856c7fe6eb5dac07be0b7229fd018d42ad2L440-R448)

**API Adjustments:**
* Updated all usages of `getReceiptQuery()` and `getRecordQuery()` to accept an optional `Client` parameter, enabling them to select the correct nodes for failover. (`Sources/Hiero/Ethereum/EthereumFlow.swift` [[1]](diffhunk://#diff-53b7a7f228757a30705ee0c01cb79a18bb4a2e463fc4317264452187f4e1bf93L83-R83); `Sources/Hiero/Token/TokenRejectFlow.swift` [[2]](diffhunk://#diff-e40ecd7170234c061e8148c2cf8b029ed95ce7d6787ca715fb2c864aed6f8e41L156-R162); `Sources/Hiero/Query.swift` [[3]](diffhunk://#diff-7a2abe6c04e554a16a457d880f0fc1cab00d32f590d1e38cef622628be747891L163-R169)

**Testing:**
* Added extensive unit tests for the new failover behavior, including default behavior, explicit node lists, and fallback to client network nodes. (`Tests/HieroUnitTests/ClientUnitTests.swift` [[1]](diffhunk://#diff-cd59de9ffbdecc2f8f3ef79446b416f01db6d7d23d2997eec807457188c965afR344-R376); `Tests/HieroUnitTests/TransactionResponseUnitTests.swift` [[2]](diffhunk://#diff-a2b870a082bc63439913ac3c262f70fc529e1a870c9f01517bede37a01f17f54R1-R111)

These changes make receipt and record queries more robust in high-throughput or high-availability scenarios, while maintaining backward compatibility by default.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #565 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
