### PR TITLE
ci: add action version comments and swift dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
@@ -71,10 +71,10 @@ jobs:
           swift-version: ${{ matrix.swift }}
 
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache SPM build dir
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .build
           key: ${{ runner.os }}-${{ matrix.swift }}-spm-${{ github.job }}-${{ hashFiles('**/Package.resolved') }}


### PR DESCRIPTION
**Description**:

Small CI hygiene changes following the OpenSSF Scorecard recommendations. This repository already scores 10/10 on the checks that can be fixed from a PR (Token-Permissions, Pinned-Dependencies, Binary-Artifacts, Dangerous-Workflow), so this PR is limited to keeping those results easy to maintain and extending Dependabot to the Swift package ecosystem.

* Add the missing `# vX.Y.Z` version comments to the three SHA-pinned actions in the `test` job of `swift-ci.yml` (`step-security/harden-runner` v2.19.1, `actions/checkout` v6.0.2, `actions/cache` v5.0.5), matching the style already used in the `format` job. No SHAs were changed; the versions were resolved from the upstream repositories' tags, and they match the "from" versions in the currently open Dependabot PRs (#639, #643, #647).
* Add a `swift` `package-ecosystem` entry to `.github/dependabot.yml` (weekly) so the Swift Package Manager dependencies in `Package.swift` / `Package.resolved` receive version-update PRs, not only security updates. This mirrors the other SDK repositories, which each cover their primary ecosystem (`cargo`, `gomod`, `pip`, `vcpkg`) next to `github-actions`.

| Check | Before | After (local scorecard) |
| --- | --- | --- |
| Token-Permissions | 10 | 10 |
| Pinned-Dependencies | 10 | 10 |
| Binary-Artifacts | 10 | 10 |
| Dangerous-Workflow | 10 | 10 |
| SAST | 6 (API) | unchanged, see notes |
| Fuzzing | 0 | unchanged, see #641 |

**Related issue(s)**:

Related to #641 (Fuzzing is tracked there and intentionally not touched here).

**Notes for reviewer**:

Intentionally not changed:

* **CodeQL / SAST.** The repository runs CodeQL through GitHub's *default setup* (languages: `swift`, `python`, `actions`), which is what currently gives the SAST check its partial score. Scorecard only recognises a SAST tool as "configured" when a workflow file calls `github/codeql-action/analyze`, but the CodeQL action rejects uploads from an advanced-setup workflow while default setup is enabled, and switching to advanced setup requires disabling default setup first (this is what hiero-sdk-python did with its `CodeQL Advanced` workflow). Doing that here would drop the Swift analysis unless a Swift build job is also added on the self-hosted runners, so it is left as a maintainer decision rather than included in this PR.
* **Fuzzing.** #641 already proposes a ClusterFuzzLite integration and has a contributor working on it.
* The open Dependabot PRs #639, #643 and #647 touch the same `uses:` lines; Dependabot will rebase them automatically after this merges.

Verification:

* `actionlint .github/workflows/swift-ci.yml` reports the same output before and after (only the pre-existing unknown self-hosted runner label notices and one SC2086 info in the swift-format build step).
* `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow,SAST,Fuzzing` gives the same results before and after (10/10/10/10, SAST and Fuzzing are not evaluated locally).
* Both YAML files parse; the Dependabot file now ends with a newline.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
