### PR TITLE
fix: replace the ping() AccountBalanceQuery probe with a COST_ANSWER getAccountInfo query

### DIFF
--- a/Sources/Hiero/PingQuery.swift
+++ b/Sources/Hiero/PingQuery.swift
@@ -4,6 +4,12 @@ import Foundation
 import GRPC
 import HieroProtobufs
 
+/// Liveness probe used by `Client.ping()` / `Client.pingAll()` and by the node health check in `Execute`.
+///
+/// Sends a `CryptoService/getAccountInfo` query for account `<shard>.<realm>.2` with
+/// `ResponseType = COST_ANSWER`: the node answers with the query fee without executing it,
+/// so nothing is charged and no operator is required. A cost response is success; a gRPC
+/// failure or a non-OK precheck is failure.
 internal struct PingQuery {
     internal init(nodeAccountId: AccountId) {
         self.nodeAccountId = nodeAccountId
@@ -56,17 +62,16 @@ extension PingQuery: Execute {
     }
 
     internal func makeRequest(_ transactionId: TransactionId?, _ nodeAccountId: AccountId) throws -> (Proto_Query, ()) {
-        let header = Proto_QueryHeader.with { $0.responseType = .answerOnly }
-
         assert(nodeAccountId == self.nodeAccountId)
 
+        // Account 2 in the node's shard/realm (`0.0.2` on every current network), as in the other SDKs.
+        let probeAccountId = AccountId(shard: nodeAccountId.shard, realm: nodeAccountId.realm, num: 2)
+
         let query = Proto_Query.with { proto in
-            proto.query = .cryptogetAccountBalance(
-                .with { proto in
-                    proto.accountID = nodeAccountId.toProtobuf()
-                    proto.header = header
-                }
-            )
+            proto.cryptoGetInfo = .with { proto in
+                proto.header = .with { $0.responseType = .costAnswer }
+                proto.accountID = probeAccountId.toProtobuf()
+            }
         }
 
         return (query, ())
@@ -75,13 +80,18 @@ extension PingQuery: Execute {
     internal func execute(_ channel: GRPC.GRPCChannel, _ request: Proto_Query, _ deadline: TimeInterval) async throws
         -> Proto_Response
     {
-        try await Proto_CryptoServiceAsyncClient(channel: channel).cryptoGetBalance(
+        try await Proto_CryptoServiceAsyncClient(channel: channel).getAccountInfo(
             request, callOptions: applyGrpcHeader(deadline: deadline))
     }
 
     internal func makeResponse(
         _ response: Proto_Response, _ context: (), _ nodeAccountId: AccountId, _ transactionId: TransactionId?
-    ) throws {}
+    ) throws {
+        guard case .cryptoGetInfo = response.response else {
+            throw HError.fromProtobuf(
+                "unexpected \(String(describing: response.response)) received, expected `cryptoGetInfo`")
+        }
+    }
 
     internal func makeErrorPrecheck(_ status: Status, _ transactionId: TransactionId?) -> HError {
         HError(

--- a/Tests/HieroUnitTests/PingQueryUnitTests.swift
+++ b/Tests/HieroUnitTests/PingQueryUnitTests.swift
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import HieroTestSupport
+import XCTest
+
+@testable import Hiero
+
+internal final class PingQueryUnitTests: HieroUnitTestCase, QueryTestable {
+    static func makeQueryProto() throws -> Proto_Query {
+        try PingQuery(nodeAccountId: AccountId(num: 3)).makeRequest(nil, AccountId(num: 3)).0
+    }
+
+    internal func test_Serialize() throws {
+        try assertQuerySerializes()
+    }
+
+    internal func test_ProbeIsCostAnswerGetAccountInfoForAccount2() throws {
+        let proto = try Self.makeQueryProto()
+
+        guard case .cryptoGetInfo(let query) = proto.query else {
+            return XCTFail("expected `cryptoGetInfo`, got \(String(describing: proto.query))")
+        }
+
+        XCTAssertEqual(query.header.responseType, .costAnswer)
+        XCTAssertEqual(try AccountId.fromProtobuf(query.accountID), AccountId(num: 2))
+        XCTAssertFalse(query.header.hasPayment)
+    }
+
+    internal func test_ProbeUsesNodeShardAndRealm() throws {
+        let node = AccountId(shard: 1, realm: 2, num: 7)
+        let proto = try PingQuery(nodeAccountId: node).makeRequest(nil, node).0
+
+        XCTAssertEqual(try AccountId.fromProtobuf(proto.cryptoGetInfo.accountID), AccountId(shard: 1, realm: 2, num: 2))
+    }
+
+    internal func test_MakeResponseRejectsWrongResponseKind() {
+        let response = Proto_Response.with { $0.cryptogetAccountBalance = .init() }
+
+        XCTAssertThrowsError(try PingQuery(nodeAccountId: 3).makeResponse(response, (), 3, nil))
+    }
+}

--- a/Tests/HieroUnitTests/__Snapshots__/PingQueryUnitTests/test_Serialize.1.txt
+++ b/Tests/HieroUnitTests/__Snapshots__/PingQueryUnitTests/test_Serialize.1.txt
@@ -1,0 +1,9 @@
+HieroProtobufs.Proto_Query:
+cryptoGetInfo {
+  header {
+    responseType: COST_ANSWER
+  }
+  accountID {
+    accountNum: 2
+  }
+}


### PR DESCRIPTION
## Description

Consensus node 0.77 removes the throttle bucket for `CryptoGetAccountBalance` ([hiero-consensus-node#25952](https://github.com/hiero-ledger/hiero-consensus-node/pull/25952)), so every `cryptoGetBalance` call answers `BUSY` once a network runs it: testnet from 10 Sep 2026, mainnet from 29 Sep 2026. `Client.ping()` / `pingAll()` and the node health check inside `Execute` used that query as the liveness probe, so after the upgrade every ping fails.

This is Stage 1 of the cross-SDK [AccountBalanceQuery deprecation proposal](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/proposals/account-balance-query-deprecation.md):

- `PingQuery` now sends `CryptoService/getAccountInfo` for account `<shard>.<realm>.2` (`0.0.2` on every current network; shard/realm are taken from the node account id being pinged, matching the JS implementation) with `ResponseType = COST_ANSWER`. The node answers with the query fee without executing the query, so nothing is charged and no operator or payment transaction is needed.
- A cost response with an OK precheck is success; a gRPC failure or a non-OK precheck is failure, exactly as before. `makeResponse` now rejects any response that is not `cryptoGetInfo`.
- Per-node targeting, backoff and node-health bookkeeping in `Client` / `Execute` are unchanged: the probe still goes to the one node being pinged through the same `executeAny` / `executeAnyInner` path.
- Purely internal; no public API change. `AccountBalanceQuery` itself is untouched (Stage 2 is a separate follow-up).

Audit of other internal uses (`grep -rn "AccountBalanceQuery\|cryptogetAccountBalance" Sources/`): the only remaining ones are `AccountBalanceQuery.swift` / `AccountBalance.swift` themselves, the exhaustive response-header switch in `Proto_Response+Extensions.swift`, a doc-comment example in `Client.swift`, and the TCK server's `getAccountBalance` JSON-RPC handler (`Sources/HieroTCK/account/AccountService.swift`), which intentionally exercises the balance query and stays as is.

## Related issue(s)

Fixes #650

## Notes for reviewer

- Built locally with `swift build` (Swift 6.3.3 command-line toolchain). This machine has no Xcode / XCTest, so `swift test --filter PingQueryUnitTests` could not run here; the new tests were exercised through a scratch executable using `@testable import Hiero` (request shape, `COST_ANSWER`, account `2` in the node's shard/realm, no payment, `makeResponse` rejecting a non-`cryptoGetInfo` response) and the `test_Serialize` snapshot file was generated from that same `String(describing:)` output. CI must confirm `HieroUnitTests` passes and that the snapshot matches.
- `swift format lint --strict --configuration .swift-format.json` passes on the changed files.
- Reference implementations: JS [hiero-sdk-js#4312](https://github.com/hiero-ledger/hiero-sdk-js/pull/4312), Java [hiero-sdk-java#2870](https://github.com/hiero-ledger/hiero-sdk-java/pull/2870), Go [hiero-sdk-go#1799](https://github.com/hiero-ledger/hiero-sdk-go/pull/1799).
- The TCK `ClientPing` suite covers acceptance criteria 1-4: https://github.com/hiero-ledger/hiero-sdk-tck/blob/main/docs/test-specifications/crypto-service/ClientPing.md
