### PR TITLE
ci: wait for mirror node fee estimation before running integration tests

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -115,7 +115,37 @@ jobs:
           mirrorNodeVersion: v0.153.0
           hieroVersion: v0.73.0
           dualMode: true
-      
+
+      - name: Wait for mirror node fee estimation
+        run: |
+          set -euo pipefail
+          # The mirror node's Java REST loads the simple fee schedule (file 0.0.113) once at startup and
+          # then only every 10 minutes. On a fresh Solo network the importer has not ingested that file
+          # yet when rest-java starts, so POST /api/v1/network/fees answers "400 Unknown transaction type"
+          # for the first ~10 minutes and FeeEstimateQueryIntegrationTests fail. Shorten the refresh
+          # interval (which restarts the pod), re-open the port-forward and wait for the first estimate.
+          kubectl -n solo set env deployment/mirror-1-restjava HIERO_MIRROR_REST_JAVA_FEE_REFRESH_INTERVAL=PT5S
+          kubectl -n solo rollout status deployment/mirror-1-restjava --timeout=5m
+          pkill -f 'port-forward svc/mirror-1-restjava' || true
+          sleep 2
+          kubectl -n solo port-forward svc/mirror-1-restjava 8084:80 > /tmp/restjava-port-forward.log 2>&1 &
+          sleep 3
+          # A minimal CryptoTransfer (Transaction > SignedTransaction > TransactionBody), no signatures.
+          echo 'Ki0KKwoICgIIARICGAISAhgDGIDC1y8iAgh4chIKEAoGCgIYAhABCgYKAhgDEAI=' | base64 -d > /tmp/fee-probe.bin
+          for _ in $(seq 1 120); do
+            code=$(curl -s -o /tmp/fee-probe.out -w '%{http_code}' -X POST \
+              -H 'Content-Type: application/protobuf' --data-binary @/tmp/fee-probe.bin \
+              'http://127.0.0.1:8084/api/v1/network/fees?mode=INTRINSIC' || true)
+            if [ "$code" = "200" ]; then
+              echo "fee estimation ready: $(cat /tmp/fee-probe.out)"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "fee estimation still unavailable: HTTP ${code} $(cat /tmp/fee-probe.out 2>/dev/null)"
+          kubectl -n solo logs deployment/mirror-1-restjava --tail=50 || true
+          exit 1
+
       - name: Run integration tests (HieroIntegrationTests)
         env:
           HIERO_PROFILE: ciIntegration


### PR DESCRIPTION
## Description

Swift CI has been red on `main` since May (every push since #526): `Build and Test SDK` jobs fail in `FeeEstimateQueryIntegrationTests` (15 of 16 tests) with

```
Fee estimate request failed: HTTP 400 - {"_status":{"messages":[{"detail":"Unknown transaction type","message":"Bad Request"}]}}
```

and the matrix fail-fast then cancels the other Swift versions, so no PR gets a green build.

The cause is a startup race in the test environment, not the SDK. The mirror node's Java REST (`FeeEstimationService`) loads the simple fee schedule (file `0.0.113`) once at startup and afterwards only every `hiero.mirror.rest-java.fee.refresh-interval` (default `PT10M`). On a fresh Solo network the importer is still ingesting the genesis record files when rest-java boots; whenever rest-java wins that race its fee calculator stays `null` and every estimate is answered with `400 Unknown transaction type` until the first refresh, 10 minutes later. Our integration run reaches the fee-estimate suite about 3 minutes after rest-java is ready, inside that window. The race is visible in today's runs of the same code: run 34349095043 (#651) failed all 15 fee tests, run 34358049611 (#652) passed them, both with the suite starting 3 minutes after rest-java. The JS SDK, with the same `hieroVersion` / `mirrorNodeVersion`, reaches its equivalent suite roughly 10 minutes in and never sees the window.

This adds a `Wait for mirror node fee estimation` step between `Prepare Hiero Solo` and the integration tests:

- sets `HIERO_MIRROR_REST_JAVA_FEE_REFRESH_INTERVAL=PT5S` on the `mirror-1-restjava` deployment (this restarts the pod),
- re-opens the `8084:80` port-forward that the Solo action created,
- polls `POST /api/v1/network/fees?mode=INTRINSIC` with a minimal unsigned CryptoTransfer until it returns 200, failing the job after 10 minutes with the rest-java log.

It adds roughly a minute to each matrix job.

## Related issue(s)

No open issue; the failure is visible on every `main` run of Swift CI since 2026-05-05.

## Notes for reviewer

- Verified on a fork with a GitHub-hosted runner (`runs-on: ubuntu-latest`, Swift 6.0 only): https://github.com/Fantomasa/hiero-sdk-swift/actions/runs/34359139457. The step took 68 s (rollout 62 s, first probe answered 200 within 6 s), then `FeeEstimateQueryIntegrationTests` and the whole `HieroIntegrationTests` suite passed (395 tests, 34 skipped, 0 failures).
- #622 and #648 (mirror node / solo-action bumps) do not change this behaviour on their own; `FeeEstimationService` is unchanged through mirror node v0.159.0.
- The long-term fix belongs in the mirror node (keep retrying the schedule load until it succeeds, or answer 503 while it is not loaded); this is a CI workaround so the suite can run against the current versions.
