### PR TITLE
chore: release v0.51.1

### DIFF
--- a/Sources/Hiero/Version.swift
+++ b/Sources/Hiero/Version.swift
@@ -3,5 +3,5 @@
 /// Contains SDK version information.
 public enum VersionInfo {
     /// The current version of the Hiero SDK.
-    public static let version = "0.51.0"
+    public static let version = "0.51.1"
 }


### PR DESCRIPTION
## Summary

Bumps `VersionInfo.version` from `0.51.0` to `0.51.1` to cut the v0.51.1 release.

This is a patch release whose purpose is to ship #652 before consensus node 0.77 reaches testnet on 10 Sep 2026 (mainnet 29 Sep 2026): from that version `CryptoGetAccountBalance` has no throttle bucket and answers `BUSY`, so `Client.ping()` / `pingAll()` and the node health check on v0.51.0 fail against upgraded networks.

## Release Highlights

The following changes have landed on `main` since v0.51.0 and ship as part of this release.

### Fixes

| PR | Description |
|----|-------------|
| [#652](https://github.com/hiero-ledger/hiero-sdk-swift/pull/652) | Replace the `Client.ping()` / `pingAll()` `AccountBalanceQuery` liveness probe with a `COST_ANSWER` `getAccountInfo` query for account `<shard>.<realm>.2` (Stage 1 of the cross-SDK [AccountBalanceQuery deprecation](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/proposals/account-balance-query-deprecation.md)). Nothing is charged and no operator is required; per-node targeting, backoff and node-health bookkeeping are unchanged. Fixes #650. |

### Maintenance

| PR | Description |
|----|-------------|
| [#644](https://github.com/hiero-ledger/hiero-sdk-swift/pull/644) | Update Solo version to 0.65.1 in CI |

## Files Changed Summary

| File | Change |
|------|--------|
| `Sources/Hiero/Version.swift` | `0.51.0` → `0.51.1` |

## Testing

Version bump only; no functional changes. Swift CI on this PR builds the package and runs `HieroUnitTests` and `HieroIntegrationTests` against Solo. The underlying fix was verified in #652, where all five `Build and Test SDK` matrix jobs passed.

## Breaking Changes

**None.** `AccountBalanceQuery` itself is untouched; its deprecation is Stage 2 and a separate follow-up.

## After merge

A maintainer needs to tag the merge commit as `v0.51.1` and publish the GitHub release; SwiftPM consumers resolve the tag.
